### PR TITLE
Removed LDAP Server Configuration

### DIFF
--- a/attributes/nodejs.rb
+++ b/attributes/nodejs.rb
@@ -6,12 +6,9 @@ override['nginx']['install_method'] = 'source'
 # Do we want the nginx proxy to perform LDAP auth?
 default['tiddlywiki5']['nodejs']['ldap_auth'] = false 
 
-default['tiddlywiki5']['nodejs']['ldap_basedn'] = "dc=example,dc=com"
-
-# Details for binding to the directory server.
-default['tiddlywiki5']['nodejs']['ldap_url'] = "ldap://ldap.example.com:389/dc=example,dc=com?uid?sub?(objectClass=inetorgperson)"
-default['tiddlywiki5']['nodejs']['ldap_binddn'] = "uid=tiddlywiki,ou=Service Accounts,dc=example,dc=com"
-default['tiddlywiki5']['nodejs']['ldap_binddn_password'] = "changeme"
+# NB: it will be necessary to override the ['nginx']['auth_ldap']
+# attributes found in the nginx_auth_ldap cookbook in order to configure
+# LDAP authentication.
 
 # Name of site as displayed by the auth dialog:
 default['tiddlywiki5']['nodejs']['ldap_secure_name'] = "Example TW5"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'peter.green@aztek-native.com'
 license          'Apache 2.0'
 description      'Installs/Configures tiddlywiki5'
 long_description 'Installs/Configures tiddlywiki5'
-version          '0.2.0'
+version          '0.3.0'
 %w{ application
     application_nginx
     application_nodejs

--- a/templates/default/load_balancer.conf.erb
+++ b/templates/default/load_balancer.conf.erb
@@ -7,15 +7,6 @@ upstream <%= @resource.application.name %> {
   server 127.0.0.1:<%= @resource.application_port %>;
 }
 
-<%- if node['tiddlywiki5']['nodejs']['ldap_auth'] == true -%>
-ldap_server dirsrv {
-  url <%= node['tiddlywiki5']['nodejs']['ldap_url'] %>;
-  binddn "<%= node['tiddlywiki5']['nodejs']['ldap_binddn'] %>";
-  binddn_passwd "<%= node['tiddlywiki5']['nodejs']['ldap_binddn_password'] %>";
-  require valid_user;
-}
-<%- end -%>
-
 server {
   listen <%= @resource.port %>;
   server_name <%= @resource.server_name.is_a?(Array) ? @resource.server_name.join(' ') : @resource.server_name %>;


### PR DESCRIPTION
I've removed the LDAP server configuration, as it makes more sense for that to reside in the `nginx_auth_ldap` cookbook, with only the virtual host configuration remaining here.
